### PR TITLE
Enable imagick

### DIFF
--- a/civicrm/Dockerfile
+++ b/civicrm/Dockerfile
@@ -59,6 +59,8 @@ RUN docker-php-ext-install bcmath \
 RUN pecl install imagick \
   && pecl install xdebug
 
+RUN docker-php-ext-enable imagick
+
 RUN a2enmod rewrite
 
 RUN a2enmod headers

--- a/publish/templates/civicrm/Dockerfile.twig
+++ b/publish/templates/civicrm/Dockerfile.twig
@@ -64,6 +64,8 @@ RUN pecl install imagick \
   && pecl install xdebug
 {% endif %}
 
+RUN docker-php-ext-enable imagick
+
 RUN a2enmod rewrite
 
 RUN a2enmod headers


### PR DESCRIPTION
I came across an issue getting Mosaico to work with CiviCRM.  I got an error that the imagick extension was missing.  Looking at the dockerfile, I can see that the php imagick module is installed but not enabled.  Adding this line will enable this module.

I presume that you will need to run your publishing script to update all of the docker files.  Unfortunately, I'm unable to do this on my machine at the moment.