### PR TITLE
Don't always restart

### DIFF
--- a/docker-compose-build.yml
+++ b/docker-compose-build.yml
@@ -26,7 +26,7 @@ services:
       - drush-cache:/buildkit/.drush
       - npm-cache:/buildkit/.npm
       - git-cache:/buildkit/app/tmp/git-cache
-    restart: on-failure
+    restart: unless-stopped
 
   mysql:
     image: mysql:5.7
@@ -34,7 +34,7 @@ services:
       MYSQL_ROOT_PASSWORD: buildkit
     volumes:
       - mysql:/var/lib/mysql
-    restart: on-failure
+    restart: unless-stopped
 
   phpmyadmin:
     image: phpmyadmin/phpmyadmin
@@ -46,13 +46,13 @@ services:
       PMA_HOST: mysql
       PMA_USER: root
       PMA_PASSWORD: buildkit
-    restart: on-failure
+    restart: unless-stopped
 
   maildev:
     image: djfarrelly/maildev
     ports:
       - "8082:80"
-    restart: on-failure
+    restart: unless-stopped
 
 volumes:
   amp:

--- a/docker-compose-build.yml
+++ b/docker-compose-build.yml
@@ -26,7 +26,7 @@ services:
       - drush-cache:/buildkit/.drush
       - npm-cache:/buildkit/.npm
       - git-cache:/buildkit/app/tmp/git-cache
-    restart: always
+    restart: on-failure
 
   mysql:
     image: mysql:5.7
@@ -34,7 +34,7 @@ services:
       MYSQL_ROOT_PASSWORD: buildkit
     volumes:
       - mysql:/var/lib/mysql
-    restart: always
+    restart: on-failure
 
   phpmyadmin:
     image: phpmyadmin/phpmyadmin
@@ -46,13 +46,13 @@ services:
       PMA_HOST: mysql
       PMA_USER: root
       PMA_PASSWORD: buildkit
-    restart: always
+    restart: on-failure
 
   maildev:
     image: djfarrelly/maildev
     ports:
       - "8082:80"
-    restart: always
+    restart: on-failure
 
 volumes:
   amp:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - drush-cache:/buildkit/.drush
       - npm-cache:/buildkit/.npm
       - git-cache:/buildkit/app/tmp/git-cache
-    restart: always
+    restart: on-failure
 
   mysql:
     image: mysql:5.7
@@ -30,7 +30,7 @@ services:
       MYSQL_ROOT_PASSWORD: buildkit
     volumes:
       - mysql:/var/lib/mysql
-    restart: always
+    restart: on-failure
 
   phpmyadmin:
     image: phpmyadmin/phpmyadmin
@@ -42,13 +42,13 @@ services:
       PMA_HOST: mysql
       PMA_USER: root
       PMA_PASSWORD: buildkit
-    restart: always
+    restart: on-failure
 
   maildev:
     image: djfarrelly/maildev
     ports:
       - "8082:80"
-    restart: always
+    restart: on-failure
 
 volumes:
   amp:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - drush-cache:/buildkit/.drush
       - npm-cache:/buildkit/.npm
       - git-cache:/buildkit/app/tmp/git-cache
-    restart: on-failure
+    restart: unless-stopped
 
   mysql:
     image: mysql:5.7
@@ -30,7 +30,7 @@ services:
       MYSQL_ROOT_PASSWORD: buildkit
     volumes:
       - mysql:/var/lib/mysql
-    restart: on-failure
+    restart: unless-stopped
 
   phpmyadmin:
     image: phpmyadmin/phpmyadmin
@@ -42,13 +42,13 @@ services:
       PMA_HOST: mysql
       PMA_USER: root
       PMA_PASSWORD: buildkit
-    restart: on-failure
+    restart: unless-stopped
 
   maildev:
     image: djfarrelly/maildev
     ports:
       - "8082:80"
-    restart: on-failure
+    restart: unless-stopped
 
 volumes:
   amp:


### PR DESCRIPTION
I've noticed that these images are always running every time I switch my laptop on.  I find this slightly annoying as it means that I have to stop them in order to run other docker images that use the same ports.  I would prefer to turn the images off and on as required.

The suggested changes make the images only restart on failure.