### PR TITLE
Fix generate script

### DIFF
--- a/publish/README.md
+++ b/publish/README.md
@@ -22,16 +22,16 @@ civicrm:
 ## Updating Dockerfiles
 
 1. From the `publish` directory, run `composer install`
-2. Make any necessary changes to the `templates` and `publish.php` script.
-3. Run `php publish.php`
+2. Make any necessary changes to the `templates` and `generate.php` script.
+3. Run `php generate.php`
 4. Check the generated directories in `publish/civicrm`
 5. Optionally, copy the contents of `publish/civicrm/php7.0` to `civicrm` with `cp -r publish/civicrm/php7.0/* civicrm`
 
-If you don't have PHP or composer installed locally you can use Docker images to run the `publish.php` script as follows:
+If you don't have PHP or composer installed locally you can use Docker images to run the `generate.php` script as follows:
 
 1. Move to the `publish` directory
 1. Run `docker run -it --rm -v "$PWD":/app composer install`
-1. Run `docker run -it --rm -v "$PWD":/usr/src/myapp -w /usr/src/myapp php php publish.php`
+1. Run `docker run -it --rm -v "$PWD/..":/usr/src/myapp -w /usr/src/myapp/publish php php generate.php`
 
 ## Publishing updates to https://hub.docker.com
 

--- a/publish/README.md
+++ b/publish/README.md
@@ -30,8 +30,8 @@ civicrm:
 If you don't have PHP or composer installed locally you can use Docker images to run the `generate.php` script as follows:
 
 1. Move to the `publish` directory
-1. Run `docker run -it --rm -v "$PWD":/app composer install`
-1. Run `docker run -it --rm -v "$PWD/..":/usr/src/myapp -w /usr/src/myapp/publish php php generate.php`
+1. Run `docker run -it --rm -u $(id -u):$(id -g) -v "$PWD":/app composer install`
+1. Run `docker run -it --rm -u $(id -u):$(id -g) -v "$PWD/..":/usr/src/myapp -w /usr/src/myapp/publish php php generate.php`
 
 ## Publishing updates to https://hub.docker.com
 

--- a/publish/generate.php
+++ b/publish/generate.php
@@ -13,7 +13,7 @@ foreach ($phpVersions as $phpVersion) {
     `mkdir -p $versionDir`;
   }
   foreach (glob($dir . '/templates/civicrm/*.twig') as $file) {
-    $outputFile = $dir . '/' . basename($file, '.twig');
+    $outputFile = $versionDir . '/' . basename($file, '.twig');
     $template = basename($file);
     file_put_contents($outputFile, $twig->render($template, ['php_version' => $phpVersion]));
   }


### PR DESCRIPTION
Spotted an issue with the `generate.php` script. It was creating all of the files in the `publish` directory.

Also the instructions needed to be updated to use `generate.php` rather than `publish.php`.