### PR TITLE
Add default settings for debugging with Visual Studio Code

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,23 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Listen for XDebug",
+            "type": "php",
+            "request": "launch",
+            "port": 9000,
+            "pathMappings": {
+                "/buildkit/build": "${workspaceRoot}/build"
+            },
+            "xdebugSettings": {
+                "max_children": 100,
+                "max_data": 100,
+                "max_depth": 10
+            }
+        }
+    ]
+}
+

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "editor.formatOnSave": false,
+  "git.ignoreLimitWarning": true
+}
+


### PR DESCRIPTION
This helps debugging with Visual Studio Code when opened from the root project folder. It facilitates debugging all the sites in the container.