### PR TITLE
Clone the whole buildkit repository

### DIFF
--- a/civicrm/Dockerfile
+++ b/civicrm/Dockerfile
@@ -86,11 +86,9 @@ WORKDIR /buildkit
 
 ENV PATH="/buildkit/bin:${PATH}"
 
-RUN git clone https://github.com/civicrm/civicrm-buildkit.git buildkit-tmp
-
-RUN mv buildkit-tmp/* buildkit-tmp/.git* .
-
-RUN rmdir buildkit-tmp
+RUN git init . \
+    && git remote add origin https://github.com/civicrm/civicrm-buildkit.git \
+    && git pull origin master
 
 # Need to create this before we configure apache, otherwise it will complain
 RUN mkdir -p .amp/apache.d

--- a/publish/civicrm/php7.2/Dockerfile
+++ b/publish/civicrm/php7.2/Dockerfile
@@ -86,11 +86,9 @@ WORKDIR /buildkit
 
 ENV PATH="/buildkit/bin:${PATH}"
 
-RUN git clone https://github.com/civicrm/civicrm-buildkit.git buildkit-tmp
-
-RUN mv buildkit-tmp/* buildkit-tmp/.git* .
-
-RUN rmdir buildkit-tmp
+RUN git init . \
+    && git remote add origin https://github.com/civicrm/civicrm-buildkit.git \
+    && git pull origin master
 
 # Need to create this before we configure apache, otherwise it will complain
 RUN mkdir -p .amp/apache.d

--- a/publish/civicrm/php7.3/Dockerfile
+++ b/publish/civicrm/php7.3/Dockerfile
@@ -86,11 +86,9 @@ WORKDIR /buildkit
 
 ENV PATH="/buildkit/bin:${PATH}"
 
-RUN git clone https://github.com/civicrm/civicrm-buildkit.git buildkit-tmp
-
-RUN mv buildkit-tmp/* buildkit-tmp/.git* .
-
-RUN rmdir buildkit-tmp
+RUN git init . \
+    && git remote add origin https://github.com/civicrm/civicrm-buildkit.git \
+    && git pull origin master
 
 # Need to create this before we configure apache, otherwise it will complain
 RUN mkdir -p .amp/apache.d

--- a/publish/civicrm/php7.4/Dockerfile
+++ b/publish/civicrm/php7.4/Dockerfile
@@ -86,11 +86,9 @@ WORKDIR /buildkit
 
 ENV PATH="/buildkit/bin:${PATH}"
 
-RUN git clone https://github.com/civicrm/civicrm-buildkit.git buildkit-tmp
-
-RUN mv buildkit-tmp/* buildkit-tmp/.git* .
-
-RUN rmdir buildkit-tmp
+RUN git init . \
+    && git remote add origin https://github.com/civicrm/civicrm-buildkit.git \
+    && git pull origin master
 
 # Need to create this before we configure apache, otherwise it will complain
 RUN mkdir -p .amp/apache.d

--- a/publish/templates/civicrm/Dockerfile.twig
+++ b/publish/templates/civicrm/Dockerfile.twig
@@ -90,11 +90,9 @@ WORKDIR /buildkit
 
 ENV PATH="/buildkit/bin:${PATH}"
 
-RUN git clone https://github.com/civicrm/civicrm-buildkit.git buildkit-tmp
-
-RUN mv buildkit-tmp/* buildkit-tmp/.git* .
-
-RUN rmdir buildkit-tmp
+RUN git init . \
+    && git remote add origin https://github.com/civicrm/civicrm-buildkit.git \
+    && git pull origin master
 
 # Need to create this before we configure apache, otherwise it will complain
 RUN mkdir -p .amp/apache.d


### PR DESCRIPTION
Fixes #57.

Currently the Dockerfile clones the repository into a temporary folder then copies the contents of this folder into the `/buildkit` folder. The problem is that it doesn't copy everything so the next line that tries to remove the temporary directory fails when this directory isn't empty (which is a good thing because it alerts us to the fact that not everything has been copied!).

There was a [recent change](https://github.com/civicrm/civicrm-buildkit/pull/526) to buildkit that adds a `.loco` directory which isn't picked up by this script. My [initial thought](https://github.com/michaelmcandrew/civicrm-buildkit-docker/commit/3df6a07594e51326432540bb9debf0ac1951fa7a) was to add this directory to the script but that approach is liable to fail again in future there are any new .files or .directories added to buildkit.

Instead I've gone for a [different approach](https://stackoverflow.com/questions/9864728/how-to-get-git-to-clone-into-current-directory/16811212#16811212) that should hopefully be more robust.
