### PR TITLE
Get xdebug working again

### DIFF
--- a/civicrm/docker-civicrm-entrypoint
+++ b/civicrm/docker-civicrm-entrypoint
@@ -6,14 +6,13 @@ CONTAINER_IP=`/sbin/ip route|awk '/default/ { print $3 }'`
 cat << EOF > /usr/local/etc/php/conf.d/debug.ini
 zend_extension=xdebug.so
 xdebug.show_error_trace=1
-xdebug.remote_enable=1
-xdebug.remote_autostart=1
-xdebug.profiler_enable_trigger=1
-xdebug.profiler_output_dir=/debug
+xdebug.mode=debug
+xdebug.start_with_request=yes
+xdebug.output_dir=/debug
 xdebug.var_display_max_depth = 8
 xdebug.var_display_max_children = 256
 xdebug.var_display_max_data = 1024 
-xdebug.remote_host=${CONTAINER_IP}
+xdebug.client_host=${CONTAINER_IP}
 max_execution_time=600
 EOF
 


### PR DESCRIPTION
The change to Xdebug 3 makes it necessary to change some configuration names. I assume that PR #62 could also solve this problem, but with the changes made here it works for me.